### PR TITLE
Use prebuilt toolchain to compile native modules

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -305,7 +305,7 @@ if ("1".equals(shouldRebuildNativeModules)) {
         } else if (OperatingSystem.current().isLinux()) {
             temp_host_tag = 'linux-x86_64'
         } else {
-            throw new GradleException("Unsupported opperating system for nodejs-mobile native builds: ${OperatingSystem.current().getName()}")
+            throw new GradleException("Unsupported operating system for nodejs-mobile native builds: ${OperatingSystem.current().getName()}")
         }
 
         String ndk_bundle_path = android.ndkDirectory


### PR DESCRIPTION
The Android build step was making a standalone toolchain for compiling native modules. Since NDK r19 [standalone toolchains are obsolete](https://developer.android.com/ndk/guides/standalone_toolchain) since prebuilt toolchains are included in the NDK distribution.

This PR changes the build configuration to use the NDK prebuilt toolchains when compiling native modules. It requires using NDK r19 or newer (which I think is required for building this module now anyway?)