### PR TITLE
fix: Remove jniLibs.srcDirs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,9 +76,6 @@ android {
     }
 
     sourceSets {
-        main {
-            jniLibs.srcDirs 'libnode/bin/'
-        }
         main.assets.srcDirs += '../install/resources/nodejs-modules'
     }
 


### PR DESCRIPTION
I needed to make this change to get this to build on RN 0.64 due to changes in Gradle, which I think automatically adds these dirs? I don't really understand what this change does however, just that it made it work for me!