### PR TITLE
Fix patch-package issue with symlinks, use lstatSync instead of statSync

### DIFF
--- a/scripts/patch-package.js
+++ b/scripts/patch-package.js
@@ -30,7 +30,7 @@ function visitPackageJSON(folderPath)
   for (var i in files) {
     let name = files[i];
     let filePath = path.join(folderPath, files[i]);
-    if(fs.statSync(filePath).isDirectory()) {
+    if (fs.lstatSync(filePath).isDirectory()) {
       visitPackageJSON(filePath);
     } else {
       if (name === 'package.json') {


### PR DESCRIPTION
I was getting errors when building in Xcode: 
```
Error: ENOENT: no such file or directory, stat .../node_modules/.bin/ucat'
    at Object.statSync (fs.js:1016:3)
    at visitPackageJSON
...
Command PhaseScriptExecution failed with a nonzero exit code
```
Due to `patch-package` file traversal encountering broken symlinks. 

Switching to `lstatSync` fixed the issue for me. As far as I know, I think it should be a simple drop-in replacement. 