### PR TITLE
doc: fix README example metro exclusionList

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The `react-native` packager monitors the project's folder for javascript package
 To avoid this error, instruct the `react-native` packager to ignore the `nodejs-project` and the platform folders where it is copied to. Edit the `metro.config.js` file in your `react-native` project's root path with the following contents if you're using recent versions of `react-native` (`>= v0.60`) and add the `blacklist` require and the following `resolver` to the module exports:
 
 ```js
-const blacklist = require('metro-config/src/defaults/blacklist');
+const blacklist = require('metro-config/src/defaults/exclusionList');
 
 module.exports = {
   resolver: {


### PR DESCRIPTION
Going through the README I noticed that `blacklist` was [renamed](https://github.com/aws-amplify/amplify-cli/issues/3295#issuecomment-833640678) to `exclusionList`.
We could follow through with this by also renaming the constant in the snippet, however the `blacklistRE` name seems to be given. I'd take your input on this and I hope that I inferred most of the contribution practices appropriately :relaxed: 