### PR TITLE
Get ndkVersion from main projects' gradle config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,8 @@ android {
     compileSdkVersion ((rootProject?.ext?.properties?.compileSdkVersion) ?: 23)
     buildToolsVersion ((rootProject?.ext?.properties?.buildToolsVersion) ?: "23.0.1")
 
+    ndkVersion project(":app").android.ndkVersion
+
     defaultConfig {
         minSdkVersion _nodeMinSdkVersion
         targetSdkVersion _nodeTargetSdkVersion


### PR DESCRIPTION
I was facing a problem in my main project when syncing with gradle files
`[(androidProjectResult.androidProject::getNdkVersion, "") must not be null](https://stackoverflow.com/questions/70926821/modelcache-safegetandroidprojectresult-androidprojectgetndkversion-must)`
This PR is a fix for that