### PR TITLE
Fix podspec source specification

### DIFF
--- a/nodejs-mobile-react-native.podspec
+++ b/nodejs-mobile-react-native.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version      = package['version']
   s.summary      = package['description']
   s.license      = package['license']
-  s.source       = { :git => 'https://github.com/nodejs-mobile/nodejs-mobile-react-native.git', :tag => 'v#{s.version}' }
+  s.source       = { :git => 'https://github.com/nodejs-mobile/nodejs-mobile-react-native.git', :tag => "v#{s.version}" }
   s.authors      = package['author']
   s.homepage     = package['homepage']
   s.platform     = :ios, '9.0'


### PR DESCRIPTION
Fixes #25. Ruby only interpolates values in double-quoted strings