### PR TITLE
Fallback to supported architectures. Fixes #34

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ android {
             }
         }
         ndk {
-            abiFilters = project(":app").android.defaultConfig.ndk.abiFilters
+            abiFilters = project(":app").android.defaultConfig.ndk.abiFilters ?: ["armeabi-v7a", "x86_64", "arm64-v8a"]
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/nodejs-mobile/nodejs-mobile-react-native/issues/34

Add the abiFilters as a fallback in `nodejs-mobile-react-native/android/build.gradle` file, if `project(":app").android.defaultConfig.ndk.abiFilters` isn't set.

This is probably the most sustainable fix since it will prioritise the project level setting if it exists and default to the constant if not. It could probably be further improved on to throw an more user friendly error message if "x86" is set at the project level.

